### PR TITLE
Add language convention to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,9 @@ Each app module registers its tools via `register_to_mcp(mcp: FastMCP)` function
 - `tests/utils/`: Custom assertions, mocks, helpers, and test data generators
 - Tests automatically mock AppleScript execution and validate response formats
 
+## Language Convention
+All code, documentation, comments, and communication in this project must be in English. This ensures consistency and accessibility for all contributors.
+
 ## Workflow Requirements
 
 ### Mandatory Convention Checks


### PR DESCRIPTION
## Summary
This PR adds a language convention section to CLAUDE.md to clarify that all project content should be in English.

## Changes
- Added "Language Convention" section to CLAUDE.md
- Placed before "Workflow Requirements" section for logical flow

## Rationale
- Ensures consistency across the project
- Makes the codebase accessible to all contributors
- Sets clear expectations for new contributors

Fixes #1